### PR TITLE
bugfix: 路径配置错误导致后端无法正常启动

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 node_modules/
-data.db
+data

--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,4 @@ package-lock.json
 backend/tmp/
 backend/static/
 frontend/build/
-data.db
+data

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,6 +1,10 @@
+// 引入 path 模块  
+import path from 'node:path';
+
 const port = process.env.BACKEND_PORT || 10888;
 const tmpDir = process.env.BACKEND_TMP_DIR || './tmp';
-const dbPath = process.env.BACKEND_DB_PATH || './data.db';
+const dbFolderPath = process.env.BACKEND_DB_PATH || './data';
+const dbPath = path.join(dbFolderPath, 'db.sqlite');
 const bodyLimit = process.env.BACKEND_BODY_LIMIT || '10mb';
 
 export default {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,5 @@ services:
     expose:
       - 10888
     volumes:
-      - ./data.db:/app/data.db
+      - ./data:/app/data
       - ./tmp:/app/tmp


### PR DESCRIPTION
详细：
由于文件./data.db一开始并不存在，docker-compose挂载时将其当做文件夹创建，
进而导致后端无法创建同名文件，抛出SqliteError: unable to open database file 
后端无法正常启动。